### PR TITLE
Fix install via VCS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,5 @@
 *~
 .idea/*
 build
-gstatus/version.py
 gstatus.egg-info
 dist

--- a/gstatus/version.py
+++ b/gstatus/version.py
@@ -1,2 +1,2 @@
 """Version"""
-VERSION = "1.0.9+fork"
+VERSION = "1.0.10"

--- a/gstatus/version.py
+++ b/gstatus/version.py
@@ -1,0 +1,2 @@
+"""Version"""
+VERSION = "1.0.9+fork"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 glustercli==0.8.3
+packaging


### PR DESCRIPTION
- Add missing `gstatus/version.py` to fix the error that's blocking the wheel build process:  

```
ImportError: cannot import name 'version' from 'gstatus'
``` 

- Bump the version number to v1.0.10
